### PR TITLE
Add updated version of Tuple

### DIFF
--- a/Seminars/Seminar13/Tuple/AllTransformer.hpp
+++ b/Seminars/Seminar13/Tuple/AllTransformer.hpp
@@ -1,0 +1,143 @@
+#include "Transformer.hpp"
+
+#define TT template<typename T, size_t N>
+
+TT
+class AllTransformer : public Transformer<T, N>
+{
+private:
+	T* data = nullptr;
+	size_t size = 0;
+
+	void copyFrom(const AllTransformer& other);
+	void moveFrom(AllTransformer&& other) noexcept;
+	void free();
+
+public:
+	AllTransformer(const T* data, size_t size);
+
+	AllTransformer(const AllTransformer& other);
+	AllTransformer& operator=(const AllTransformer& other);
+
+	AllTransformer(AllTransformer&& other) noexcept;
+	AllTransformer& operator=(AllTransformer&& other) noexcept;
+
+	const size_t getSize() const;
+
+	Tuple<T, N>& transform(Tuple<T, N>& tuple) const override;
+
+	Transformer<T, N>* clone() const override;
+
+	~AllTransformer() noexcept;
+};
+
+TT
+AllTransformer<T, N>::AllTransformer(const T* data, size_t size) : Transformer<T, N>()
+{
+	if (!data) return;
+
+	this->size = size;
+
+	this->data = new T[this->size];
+	for (size_t i = 0; i < getSize(); i++)
+		this->data[i] = data[i];
+}
+
+TT
+AllTransformer<T, N>::AllTransformer(const AllTransformer<T, N>& other) : Transformer<T, N>(other)
+{
+	copyFrom(other);
+}
+
+TT
+AllTransformer<T, N>& AllTransformer<T, N>::operator=(const AllTransformer<T, N>& other)
+{
+	if (this != &other)
+	{
+		Transformer<T, N>::operator=(other);
+		free();
+		copyFrom(other);
+	}
+
+	return *this;
+}
+
+TT
+AllTransformer<T, N>::AllTransformer(AllTransformer<T, N>&& other) noexcept : Transformer<T, N>(std::move(other))
+{
+	moveFrom(std::move(other));
+}
+
+TT
+AllTransformer<T, N>& AllTransformer<T, N>::operator=(AllTransformer<T, N>&& other) noexcept
+{
+	if (this != &other)
+	{
+		Transformer<T, N>::operator=(std::move(other));
+		free();
+		moveFrom(std::move(other));
+	}
+
+	return *this;
+}
+
+TT
+const size_t AllTransformer<T, N>::getSize() const
+{
+	return this->size;
+}
+
+TT
+Tuple<T, N>& AllTransformer<T, N>::transform(Tuple<T, N>& tuple) const
+{
+	for (size_t i = 0; i < getSize(); i++)
+	{
+		if (i >= tuple.getSize()) // the same as i >= N
+			return tuple;
+
+		tuple[i] = this->data[i];
+	}
+
+	return tuple;
+}
+
+TT
+Transformer<T, N>* AllTransformer<T, N>::clone() const
+{
+	return new AllTransformer(*this);
+}
+
+TT
+AllTransformer<T, N>::~AllTransformer() noexcept
+{
+	free();
+}
+
+TT
+void AllTransformer<T, N>::copyFrom(const AllTransformer<T, N>& other)
+{
+	this->size = other.size;
+
+	this->data = new T[this->size];
+	for (size_t i = 0; i < this->size; i++)
+		this->data[i] = other.data[i];
+}
+
+TT
+void AllTransformer<T, N>::moveFrom(AllTransformer<T, N>&& other) noexcept
+{
+	this->data = other.data;
+	this->size = other.size;
+
+	other.data = nullptr;
+	other.size = 0;
+}
+
+TT
+void AllTransformer<T, N>::free()
+{
+	delete[] this->data;
+
+	this->data = nullptr;
+	this->size = 0;
+}

--- a/Seminars/Seminar13/Tuple/ChangeAtTransformer.hpp
+++ b/Seminars/Seminar13/Tuple/ChangeAtTransformer.hpp
@@ -1,0 +1,37 @@
+#include "Transformer.hpp"
+
+#define TT template<typename T, size_t N>
+
+TT
+class ChangeAtTransformer : public Transformer<T, N>
+{
+private:
+	T element;
+	size_t index = 0;
+
+public:
+	ChangeAtTransformer(size_t index, const T& element);
+
+	Tuple<T, N>& transform(Tuple<T, N>& tuple) const override;
+
+	Transformer<T, N>* clone() const override;
+};
+
+TT
+ChangeAtTransformer<T, N>::ChangeAtTransformer(size_t index, const T& element)
+	: Transformer<T, N>(), element(element), index(index) {}
+
+TT
+Tuple<T, N>& ChangeAtTransformer<T, N>::transform(Tuple<T, N>& tuple) const
+{
+	if (index >= tuple.getSize()) return tuple;
+
+	tuple[index] = element;
+	return tuple;
+}
+
+TT
+Transformer<T, N>* ChangeAtTransformer<T, N>::clone() const
+{
+	return new ChangeAtTransformer(*this);
+}

--- a/Seminars/Seminar13/Tuple/TransformationsContainer.hpp
+++ b/Seminars/Seminar13/Tuple/TransformationsContainer.hpp
@@ -1,0 +1,210 @@
+#include "Transformer.hpp"
+
+#define TT template<typename T, size_t N>
+
+TT
+class Transformations
+{
+private:
+	Transformer<T, N>** container = nullptr;
+	size_t size = 0;
+	size_t capacity = 0;
+
+	Transformations(size_t newSize);
+	void resize(size_t newCapacity);
+
+	const unsigned int getNextPowerOfTwo(unsigned int n) const;
+	const unsigned int allocateCapacity(unsigned int size) const;
+
+	void copyFrom(const Transformations& other);
+	void moveFrom(Transformations&& other) noexcept;
+	void free();
+
+public:
+	Transformations();
+
+	Transformations(const Transformations& other);
+	Transformations& operator=(const Transformations& other);
+
+	Transformations(Transformations&& other) noexcept;
+	Transformations& operator=(Transformations&& other) noexcept;
+
+	const size_t getSize() const;
+	const size_t getCapacity() const;
+
+	void addTransformer(Transformer<T, N>* transformer);
+	void addTransformer(const Transformer<T, N>& transformer);
+
+	const Transformer<T, N>& operator[](size_t index) const;
+	Transformer<T, N>& operator[](size_t index);
+
+	Tuple<T, N>& transformAll(Tuple<T, N>& tuple) const;
+
+	~Transformations() noexcept;
+};
+
+TT
+Transformations<T, N>::Transformations() : Transformations(4) {}
+
+TT
+Transformations<T, N>::Transformations(size_t newSize) : size(0)
+{
+	this->capacity = allocateCapacity(newSize);
+	this->container = new Transformer<T, N>* [this->capacity];
+}
+
+TT
+Transformations<T, N>::Transformations(const Transformations<T, N>& other)
+{
+	copyFrom(other);
+}
+
+TT
+Transformations<T, N>& Transformations<T, N>::operator=(const Transformations<T, N>& other)
+{
+	if (this != &other)
+	{
+		free();
+		copyFrom(other);
+	}
+
+	return *this;
+}
+
+TT
+Transformations<T, N>::Transformations(Transformations<T, N>&& other) noexcept
+{
+	moveFrom(std::move(other));
+}
+
+TT
+Transformations<T, N>& Transformations<T, N>::operator=(Transformations<T, N>&& other) noexcept
+{
+	if (this != &other)
+	{
+		free();
+		moveFrom(std::move(other));
+	}
+
+	return *this;
+}
+
+TT
+const size_t Transformations<T, N>::getSize() const
+{
+	return this->size;
+}
+
+TT
+const size_t Transformations<T, N>::getCapacity() const
+{
+	return this->capacity;
+}
+
+TT
+void Transformations<T, N>::addTransformer(const Transformer<T, N>& transformer)
+{
+	if (getSize() >= getCapacity())
+		resize(getCapacity() * 2);
+
+	this->container[this->size++] = transformer.clone();
+}
+
+TT
+void Transformations<T, N>::addTransformer(Transformer<T, N>* transformer)
+{
+	if (getSize() >= getCapacity())
+		resize(getCapacity() * 2);
+
+	this->container[this->size++] = transformer;
+	transformer = nullptr;
+}
+
+TT
+const Transformer<T, N>& Transformations<T, N>::operator[](size_t index) const
+{
+	return this->container[index];
+}
+
+TT
+Transformer<T, N>& Transformations<T, N>::operator[](size_t index)
+{
+	return this->container[index];
+}
+
+TT
+Tuple<T, N>& Transformations<T, N>::transformAll(Tuple<T, N>& tuple) const
+{
+	for (size_t i = 0; i < getSize(); i++)
+		tuple = this->container[i]->transform(tuple);
+
+	return tuple;
+}
+
+TT
+Transformations<T, N>::~Transformations() noexcept
+{
+	free();
+}
+
+TT
+const unsigned int Transformations<T, N>::getNextPowerOfTwo(unsigned int n) const
+{
+	if (n == 0) return 1;
+
+	while (n & (n - 1))
+		n &= (n - 1);
+
+	return n << 1;
+}
+
+TT
+const unsigned int Transformations<T, N>::allocateCapacity(unsigned int size) const
+{
+	return std::max(getNextPowerOfTwo(size + 1), 8u);
+}
+
+TT
+void Transformations<T, N>::resize(size_t newCapacity)
+{
+	Transformer<T, N>** newTransformers = new Transformer<T, N>* [newCapacity];
+	for (size_t i = 0; i < getSize(); i++)
+		newTransformers[i] = this->container[i];
+
+	delete[] this->container;
+	this->container = newTransformers;
+	this->capacity = newCapacity;
+}
+
+TT
+void Transformations<T, N>::copyFrom(const Transformations<T, N>& other)
+{
+	this->size = other.size;
+	this->capacity = other.capacity;
+
+	this->container = new Transformer<T, N> * [this->capacity];
+	for (size_t i = 0; i < this->capacity; i++)
+		this->container[i] = other.container[i]->clone();
+}
+
+TT
+void Transformations<T, N>::moveFrom(Transformations<T, N>&& other) noexcept
+{
+	this->container = other.container;
+	this->size = other.size;
+	this->capacity = other.capacity;
+
+	other.container = nullptr;
+	other.size = other.capacity = 0;
+}
+
+TT
+void Transformations<T, N>::free()
+{
+	for (size_t i = 0; i < this->size; i++)
+		delete this->container[i];
+
+	delete[] this->container;
+	this->container = nullptr;
+	this->size = this->capacity = 0;
+}

--- a/Seminars/Seminar13/Tuple/Transformer.hpp
+++ b/Seminars/Seminar13/Tuple/Transformer.hpp
@@ -1,0 +1,15 @@
+#include "Tuple.hpp"
+
+#define TT template<typename T, size_t N>
+
+TT
+class Transformer
+{
+public:
+	Transformer() = default;
+
+	virtual Tuple<T, N>& transform(Tuple<T, N>& tuple) const = 0;
+	virtual Transformer<T, N>* clone() const = 0;
+
+	virtual ~Transformer() noexcept = default;
+};

--- a/Seminars/Seminar13/Tuple/Tuple.hpp
+++ b/Seminars/Seminar13/Tuple/Tuple.hpp
@@ -1,0 +1,45 @@
+#include <iostream>
+
+#define TT template<typename T, size_t N>
+
+TT
+class Tuple
+{
+private:
+	T data[N];
+
+public:
+	const size_t getSize() const;
+
+	const T& operator[](size_t index) const;
+	T& operator[](size_t index);
+
+	void print() const;
+};
+
+TT
+const size_t Tuple<T, N>::getSize() const
+{
+	return N; // Not needed as getter function, because the length is given in template
+}
+
+TT
+const T& Tuple<T, N>::operator[](size_t index) const
+{
+	return this->data[index];
+}
+
+TT
+T& Tuple<T, N>::operator[](size_t index)
+{
+	return this->data[index];
+}
+
+TT
+void Tuple<T, N>::print() const
+{
+	std::cout << "[ ";
+	for (size_t i = 0; i < N; i++)
+		std::cout << this->data[i] << ' ';
+	std::cout << "]";
+}


### PR DESCRIPTION
- Removed enum in Transformer.hpp
- Removed transformerFactory due to further complications with the constructors of AllTransformer.hpp and ChangeAtTransformer.hpp and also the availability of addTransformer() function with two overloads
- Added an additional comment next to getSize() function in Tuple.hpp that the getter is not needed due to the fact that the template contains size N
- Fixed some typos in copyFrom() function in TransformerContainer.hpp
- Fixed some typos in the constructor in AllTransformer.hpp - other.size => size
- Added an additional operator overload of [] in TransformerContainer.hpp